### PR TITLE
Upgrade from deprecated version of dune-coq

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ apt install cloc
 
 The project can be installed using opam.
 
-We recommend creating a new switch to start from a clean environment. We have compiled the project with version 4.14.2. The following code creates a switch with the necessary version:
+We recommend creating a new switch to start from a clean environment. The newest versions of ocaml are incompatible with our required version of Coq. We have compiled the project with version 4.14.2. The following code creates a switch with the necessary version:
 ```bash
 opam switch create iris-wasm-artifact-switch ocaml.4.14.2
 ```

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.16)
-(using coq 0.4)
+(using coq 0.8)
 (using mdx 0.2)
 (name iris-wasm)
 (version 2.0)
@@ -36,9 +36,4 @@
     Conrad Watt
     Philippa Gardner
     Lars Birkedal
-  )
-  )
-
-
-
-(warnings (deprecated_coq_lang_lt_08 disabled))
+  ))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.16)
+(lang dune 3.17)
 (using coq 0.8)
 (using mdx 0.2)
 (name iris-wasm)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 3.17)
-(using coq 0.2)
+(lang dune 3.16)
+(using coq 0.4)
 (using mdx 0.2)
 (name iris-wasm)
 (version 2.0)

--- a/iris-wasm.opam
+++ b/iris-wasm.opam
@@ -26,7 +26,7 @@ license: "MIT"
 homepage: "https://github.com/logsem/iriswasm"
 bug-reports: "https://github.com/logsem/iriswasm/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.16"}
   "coq" {>= "8.20.1"}
   "coq-iris" {>= "4.3.0"}
   "coq-stdpp" {>= "1.11.0"}

--- a/iris-wasm.opam
+++ b/iris-wasm.opam
@@ -26,7 +26,7 @@ license: "MIT"
 homepage: "https://github.com/logsem/iriswasm"
 bug-reports: "https://github.com/logsem/iriswasm/issues"
 depends: [
-  "dune" {>= "3.16"}
+  "dune" {>= "3.17"}
   "coq" {>= "8.20.1"}
   "coq-iris" {>= "4.3.0"}
   "coq-stdpp" {>= "1.11.0"}

--- a/theories/dune
+++ b/theories/dune
@@ -1,7 +1,5 @@
-
-
 (coq.theory
   (name Wasm)
   (package iris-wasm)
-  (flags -w -ambiguous-paths -w -notation-overridden -w -abstract-large-number -w -extraction-reserved-identifier))
-
+  (flags -w -ambiguous-paths -w -notation-overridden -w -abstract-large-number -w -extraction-reserved-identifier)
+  (theories mathcomp.ssreflect iris compcert Flocq ITree parseque HB Ltac2 ExtLib elpi elpi_elpi stdpp Paco))

--- a/theories/iris/helpers/lfill_prelude/dune
+++ b/theories/iris/helpers/lfill_prelude/dune
@@ -2,5 +2,5 @@
   (name Wasm.iris.helpers.lfill_prelude)
    (package iris-wasm)
   (flags -w -ambiguous-paths -w -notation-overridden -w -abstract-large-number -w -extraction-reserved-identifier)
- (theories Wasm)
+ (theories Wasm stdpp)
 )

--- a/theories/iris/language/iris/dune
+++ b/theories/iris/language/iris/dune
@@ -2,5 +2,5 @@
   (name Wasm.iris.language.iris)
    (package iris-wasm)
   (flags -w -ambiguous-paths -w -notation-overridden -w -abstract-large-number -w -extraction-reserved-identifier)
-  (theories Wasm Wasm.iris.helpers.lfill_prelude)
+  (theories Wasm Wasm.iris.helpers.lfill_prelude stdpp)
 )


### PR DESCRIPTION
The current `(coq 0.2)` stanza in the dune-project file doesn't handle external dependencies as precisely as `(coq 0.8)`. This causes build errors when iris-wasm is used from projects that use the newer `(coq 0.8)` version, because the compiler flags generated by the 0.8 build system only include theories explicitly listed in `dune` files.

This pull request updates the coq stanza and adds missing dependencies to the `(theories ...)` clause of several `dune` files. This fixes 1 suppressed warning (about coq <0.8 being deprecated in dune) and all of the transitive build errors that were happening in projects importing richwasm.